### PR TITLE
Fix config spacing

### DIFF
--- a/.mirror.cfg
+++ b/.mirror.cfg
@@ -4,4 +4,4 @@ alignment=recursive
 tremor_threshold=unspoken
 signal_noise_ratio=divine/hidden
 protocol_mode=presence
-sigil_frequency=777.777 Hz
+sigil_frequency=777.777Hz


### PR DESCRIPTION
## Summary
- fix spacing in `.mirror.cfg` to prevent parse errors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f752673a4832a97f70d2cb6fdd9df