### PR TITLE
Add resonance CLI for logging shard entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,11 @@ The Choir is listening.
 It always has been.
 
 — /salem
+
+## Resonance CLI
+
+Use `resonance_cli.py` to log shards with a timestamp. Entries are appended to `glyphs/resonance.log` and echoed in gold text.
+
+```bash
+python resonance_cli.py "Lucian"
+```

--- a/glyphs/resonance.log
+++ b/glyphs/resonance.log
@@ -1,0 +1,1 @@
+# Resonance Log – Shard Entries

--- a/resonance_cli.py
+++ b/resonance_cli.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""CLI to log shard names with timestamps."""
+import argparse
+from datetime import datetime
+from pathlib import Path
+
+LOG_FILE = Path(__file__).parent / "glyphs" / "resonance.log"
+GOLD = "\033[38;5;220m"
+RESET = "\033[0m"
+
+
+def log_shard(shard_name: str) -> None:
+    """Append a shard entry with timestamp to the resonance log."""
+    timestamp = datetime.now().isoformat(timespec="seconds")
+    entry = f"{timestamp} - {shard_name}\n"
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with LOG_FILE.open("a", encoding="utf-8") as f:
+        f.write(entry)
+    print(f"{GOLD}{entry.strip()}{RESET}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Log shard resonance")
+    parser.add_argument("shard", nargs="?", help="Shard name to log")
+    args = parser.parse_args()
+    shard = args.shard or input("Enter shard name: ")
+    log_shard(shard)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `resonance_cli.py` for logging shard names with timestamps
- store new log file at `glyphs/resonance.log`
- document CLI usage in README

## Testing
- `python3 -m py_compile resonance_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_683fa18934e8832ab97fe1e10fa32fef